### PR TITLE
cli: add storing related children in temporary migration field

### DIFF
--- a/cds_migrator_kit/records/cli.py
+++ b/cds_migrator_kit/records/cli.py
@@ -44,7 +44,7 @@ def load_records(sources, source_type, eager, model=None, rectype=None):
         with click.progressbar(data) as records:
             for item in records:
                 dump = CDSRecordDump(data=item, dojson_model=model)
-
+                click.echo('Processing item {0}...'.format(item['recid']))
                 logger.add_item(item, rectype=rectype)
                 try:
                     dump.prepare_revisions()
@@ -64,19 +64,19 @@ def load_records(sources, source_type, eager, model=None, rectype=None):
                 except LossyConversion as e:
                     cli_logger.error('[DATA ERROR]: {0}'.format(e.message))
                     JsonLogger().add_log(e, output=item, rectype=rectype)
-                except AttributeError as e:
-                    current_app.logger.error('Model missing')
-                    JsonLogger().add_log(e, output=item, rectype=rectype)
-                    # raise e
-                except TypeError as e:
-                    current_app.logger.error(
-                        'Model missing recid:{}'.format(item['recid']))
-                    JsonLogger().add_log(e, output=item, rectype=rectype)
-                    # raise e
-                except KeyError as e:
-                    current_app.logger.error(
-                        'Model missing recid:{}'.format(item['recid']))
-                    JsonLogger().add_log(e, output=item, rectype=rectype)
+                # except AttributeError as e:
+                #     current_app.logger.error('Model missing')
+                #     JsonLogger().add_log(e, output=item, rectype=rectype)
+                #     # raise e
+                # except TypeError as e:
+                #     current_app.logger.error(
+                #         'Model missing recid:{}'.format(item['recid']))
+                #     JsonLogger().add_log(e, output=item, rectype=rectype)
+                #     # raise e
+                # except KeyError as e:
+                #     current_app.logger.error(
+                #         'Model missing recid:{}'.format(item['recid']))
+                #     JsonLogger().add_log(e, output=item, rectype=rectype)
                 except Exception as e:
                     cli_logger.warning(e)
                     raise e
@@ -106,7 +106,7 @@ def report():
 @click.option(
     '--rectype',
     '-x',
-    help='Record ID to load (NOTE: will load only one record!).',
+    help='Type of record to load (f.e serial).',
     default=None)
 @with_appcontext
 def dryrun(sources, source_type, recid, rectype, model=None):

--- a/cds_migrator_kit/records/views.py
+++ b/cds_migrator_kit/records/views.py
@@ -51,7 +51,7 @@ def send_json(rectype, recid):
     """Serves static json preview output files."""
     cli_logger.warning('View reached')
     cli_logger.warning(CDS_MIGRATOR_KIT_LOGS_PATH)
-    cli_logger.warning('{0}_{1}.json'.format(rectype, recid))
-    return send_from_directory(
-        current_app.config['CDS_MIGRATOR_KIT_LOGS_PATH'],
+    cli_logger.warning('{0}/{1}_{2}.json'.format(rectype, rectype, recid))
+    return send_from_directory('{0}{1}/'.format(
+        current_app.config['CDS_MIGRATOR_KIT_LOGS_PATH'], rectype),
         '{0}_{1}.json'.format(rectype, recid))

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,11 @@ tests_require = [
     'check-manifest>=0.35',
     'coverage>=4.4.1',
     'isort>=4.3',
+    'pluggy==0.11.0',
     'pydocstyle>=2.0.0',
     'pytest-cov>=2.5.1',
     'pytest-pep8>=1.0.6',
-    'pytest>=3.8.1,<5.0.0',
+    'pytest==4.0.0',
     'pytest-invenio>=1.0.5,<1.1.0',
 ]
 


### PR DESCRIPTION
* adds the related recids from legacy found to have the same series in _migration_relation_<relation>_field

* it is meant to be generic to work for keywords and multiparts too, related records as well to have temporary step

