### PR TITLE
global: allowed hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
   - REQUIREMENTS=devel
 
 python:
-  - "2.7"
   - "3.5"
 
 before_install:
@@ -59,6 +58,6 @@ deploy:
   distributions: "compile_catalog sdist bdist_wheel"
   on:
     tags: true
-    python: "2.7"
+    python: "3.6"
     repo: CERNDocumentServer/cds-migrator-kit
     condition: $DEPLOY = true

--- a/cds_migrator_kit/config.py
+++ b/cds_migrator_kit/config.py
@@ -106,7 +106,11 @@ SESSION_COOKIE_SECURE = True
 #: provided, the allowed hosts variable is set to localhost. In production it
 #: should be set to the correct host and it is strongly recommended to only
 #: route correct hosts to the application.
-APP_ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+APP_ALLOWED_HOSTS = []
+if os.environ.get("ALLOWED_HOST"):
+    APP_ALLOWED_HOSTS.append(os.environ.get("ALLOWED_HOST"))
+if os.environ.get("HOSTNAME"):
+    APP_ALLOWED_HOSTS.append(os.environ.get("HOSTNAME"))
 APP_DEFAULT_SECURE_HEADERS['force_https'] = False
 APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {}
 

--- a/cds_migrator_kit/records/handlers.py
+++ b/cds_migrator_kit/records/handlers.py
@@ -12,20 +12,24 @@ import logging
 
 from .log import JsonLogger
 
-logger = logging.getLogger('migrator')
+cli_logger = logging.getLogger('migrator')
 
 
-def migration_exception_handler(exc, output, key, value, **kwargs):
-    """Migration exception handling - log to files.
+def migration_exception_handler(logger):
+    """Create a migration exception handler with a specific logger."""
+    def inner(exc, output, key, value, **kwargs):
+        """Migration exception handling - log to files.
 
-    :param exc: exception
-    :param output: generated output version
-    :param key: MARC field ID
-    :param value: MARC field value
-    :return:
-    """
-    logger.error(
-        '#RECID: #{0} - {1}  MARC FIELD: *{2}*, input value: {3}, -> {4}, '
-        .format(output['recid'], exc.message, key, value, output)
-    )
-    JsonLogger().add_log(exc, key, value, output, **kwargs)
+        :param exc: exception
+        :param output: generated output version
+        :param key: MARC field ID
+        :param value: MARC field value
+        :return:
+        """
+        recid = output.get('recid', None) or output['legacy_recid']
+        cli_logger.error(
+            '#RECID: #{0} - {1}  MARC FIELD: *{2}*, input value: {3}, -> {4}, '
+            .format(recid, exc.message, key, value, output)
+        )
+        logger.add_log(exc, key, value, output, **kwargs)
+    return inner

--- a/cds_migrator_kit/records/log.py
+++ b/cds_migrator_kit/records/log.py
@@ -8,6 +8,7 @@
 
 """CDS Migrator Records loggers."""
 
+import copy
 import json
 import logging
 import os
@@ -15,8 +16,11 @@ import os
 from cds_dojson.marc21.fields.books.errors import ManualMigrationRequired, \
     MissingRequiredField, UnexpectedValue
 from flask import current_app
+from fuzzywuzzy import fuzz
 
 from cds_migrator_kit.records.errors import LossyConversion
+from cds_migrator_kit.records.utils import clean_exception_message, \
+    compare_titles, same_issn
 
 
 def set_logging():
@@ -49,130 +53,92 @@ logger = logging.getLogger('migrator')
 class JsonLogger(object):
     """Log migration statistic to file controller."""
 
-    def __init__(self):
+    LOG_FILEPATH = None
+
+    @classmethod
+    def get_json_logger(cls, rectype):
+        """Get JsonLogger instance based on the rectype."""
+        if rectype == 'serial':
+            return SerialJsonLogger()
+        elif rectype == 'document':
+            return DocumentJsonLogger()
+        elif rectype == 'multipart':
+            return MultipartJsonLogger()
+        else:
+            raise Exception('Invalid rectype: {}'.format(rectype))
+
+    def __init__(self, stats_filename, records_filename):
         """Constructor."""
         self._logs_path = current_app.config['CDS_MIGRATOR_KIT_LOGS_PATH']
+        self.stats = {}
+        self.records = {}
+        self.STAT_FILEPATH = os.path.join(self._logs_path, stats_filename)
+        self.RECORD_FILEPATH = os.path.join(self._logs_path, records_filename)
 
-        self.LOG_FILEPATH = os.path.join(self._logs_path, 'stats.json')
-        self.LOG_SERIALS = os.path.join(self._logs_path, 'serials.json')
         if not os.path.exists(self._logs_path):
             os.makedirs(self._logs_path)
-        if not os.path.exists(self.LOG_FILEPATH):
-            with open(self.LOG_FILEPATH, "w+") as f:
-                json.dump([], f, indent=2)
-        if not os.path.exists(self.LOG_SERIALS):
-            with open(self.LOG_SERIALS, "w") as f:
-                json.dump([], f, indent=2)
 
-    @staticmethod
-    def clean_stats_file():
-        """Removes contents of the statistics file."""
-        filepath = os.path.join(
-            current_app.config['CDS_MIGRATOR_KIT_LOGS_PATH'], 'stats.json')
-        with open(filepath, 'w') as f:
-            f.write('[]')
-            f.close()
-
-    @staticmethod
-    def get_stat_by_recid(recid, stats_json):
-        """Search for existing stats of given recid."""
-        return next(
-            (item for item in stats_json if item['recid'] == recid), None)
-
-    def render_stats(self):
+    def load(self):
         """Load stats from file as json."""
-        logger.warning(self.LOG_FILEPATH)
-        with open(self.LOG_FILEPATH, "r") as f:
-            all_stats = json.load(f)
-            return all_stats
+        logger.warning(self.STAT_FILEPATH)
+        with open(self.STAT_FILEPATH, "r") as f:
+            self.stats = json.load(f)
+        with open(self.RECORD_FILEPATH, "r") as f:
+            self.records = json.load(f)
 
-    def create_output_file(self, file, output):
-        """Create json preview output file."""
-        try:
-            filename = os.path.join(
-                current_app.config['CDS_MIGRATOR_KIT_LOGS_PATH'],
-                "{0}/{1}.json".format(output['_migration']['record_type'],
-                                      file))
-            with open(filename, "w+") as f:
-                json.dump(output, f, indent=2)
-        except Exception as e:
-            raise e
+    def save(self):
+        """Save stats from file as json."""
+        logger.warning(self.STAT_FILEPATH)
+        with open(self.STAT_FILEPATH, "w") as f:
+            json.dump(self.stats, f)
+        with open(self.RECORD_FILEPATH, "w") as f:
+            json.dump(self.records, f)
 
-    def add_recid_to_serial(self,  current_entry, similar_series, ratio):
-        """Add record id to existing serial stats."""
-        all_stats = JsonLogger().render_stats()
-        with open(self.LOG_FILEPATH, "w+") as f:
-            record_stats = JsonLogger.get_stat_by_recid(
-                similar_series['recid'], all_stats)
-            if ratio < 100:
-                record_stats['similar_series'].append(current_entry['recid'])
-            else:
-                record_stats['exact_series'].append(current_entry['recid'])
-            json.dump(all_stats, f, indent=2)
+    def add_recid_to_stats(self, recid, **kwargs):
+        """Add recid to stats."""
+        pass
 
-    def add_extracted_records(self, recid, index):
-        """Add additionally extracted records from many series."""
-        all_stats = JsonLogger().render_stats()
-        with open(self.LOG_FILEPATH, "w+") as f:
-            record_stats = JsonLogger.get_stat_by_recid(
-                recid, all_stats)
-            record_stats['extracted_records'].append(index)
-            json.dump(all_stats, f, indent=2)
+    def add_record(self, record, **kwargs):
+        """Add record to list of collected records."""
+        pass
 
-    def add_log(self, exc, key=None, value=None, output=None, rectype=None):
+    def add_log(self, exc, key=None, value=None, output=None):
         """Add exception log."""
-        all_stats = JsonLogger().render_stats()
-        with open(self.LOG_FILEPATH, "w+") as f:
-            record_stats = JsonLogger.get_stat_by_recid(output['recid'],
-                                                        all_stats)
-            if not record_stats:
-                record_stats = {'recid': output['recid'],
-                                'record_type': rectype,
-                                'manual_migration': [],
-                                'unexpected_value': [],
-                                'missing_required_field': [],
-                                'lost_data': [],
-                                'clean': False,
-                                'similar_series': [],
-                                'exact_series': [],
-                                'extracted_records': []
-                                }
-                all_stats.append(record_stats)
-            self.resolve_error_type(exc, record_stats, key, value)
-            json.dump(all_stats, f, indent=2)
+        self.resolve_error_type(exc, output, key, value)
 
-    def add_item(self, output, rectype=None):
-        """Add empty log item."""
-        all_stats = JsonLogger().render_stats()
-        with open(self.LOG_FILEPATH, "w+") as f:
-            record_stats = JsonLogger.get_stat_by_recid(output['recid'],
-                                                        all_stats)
-            if not record_stats:
-                record_stats = {'recid': output['recid'],
-                                'record_type': rectype,
-                                'manual_migration': [],
-                                'unexpected_value': [],
-                                'missing_required_field': [],
-                                'lost_data': [],
-                                'clean': True,
-                                'similar_series': [],
-                                'exact_series': [],
-                                'extracted_records': [],
-                                }
-                all_stats.append(record_stats)
-                json.dump(all_stats, f, indent=2)
-
-    def resolve_error_type(self, exc, rec_stats, key, value):
+    def resolve_error_type(self, exc, output, key, value):
         """Check the type of exception and log to dict."""
+        recid = output.get('recid', None) or output['legacy_recid']
+        rec_stats = self.stats[recid]
         rec_stats['clean'] = False
         if isinstance(exc, ManualMigrationRequired):
-            rec_stats['manual_migration'].append(key)
+            rec_stats['manual_migration'].append(dict(
+                key=key,
+                value=value,
+                subfield=exc.subfield,
+                message=clean_exception_message(exc.message)
+            ))
         elif isinstance(exc, UnexpectedValue):
-            rec_stats['unexpected_value'].append((key, value))
+            rec_stats['unexpected_value'].append(dict(
+                key=key,
+                value=value,
+                subfield=exc.subfield,
+                message=clean_exception_message(exc.message)
+            ))
         elif isinstance(exc, MissingRequiredField):
-            rec_stats['missing_required_field'].append(key)
+            rec_stats['missing_required_field'].append(dict(
+                key=key,
+                value=value,
+                subfield=exc.subfield,
+                message=clean_exception_message(exc.message)
+            ))
         elif isinstance(exc, LossyConversion):
-            rec_stats['lost_data'] = list(exc.missing)
+            rec_stats['lost_data'].append(dict(
+                key=key,
+                value=value,
+                missing=list(exc.missing),
+                message=exc.message
+            ))
         elif isinstance(exc, KeyError):
             rec_stats['unexpected_value'].append(str(exc))
         elif isinstance(exc, TypeError) or isinstance(exc, AttributeError):
@@ -182,22 +148,161 @@ class JsonLogger(object):
         else:
             raise exc
 
-    def add_related_child(self, stored_parent, rectype, related_recid):
-        """Dumps recids picked up during migration in the output file."""
-        if '_index' in stored_parent:
-            filename = '{0}/{1}_{2}_{3}.json'.format(
-                rectype, rectype, stored_parent['recid'],
-                stored_parent['_index'])
+
+class DocumentJsonLogger(JsonLogger):
+    """Log document migration statistic to file controller."""
+
+    def __init__(self):
+        """Constructor."""
+        super().__init__('document_stats.json', 'document_records.json')
+
+    def add_recid_to_stats(self, recid):
+        """Add empty log item."""
+        if recid not in self.stats:
+            self.stats[recid] = {
+                'recid': recid,
+                'manual_migration': [],
+                'unexpected_value': [],
+                'missing_required_field': [],
+                'lost_data': [],
+                'clean': True,
+            }
+
+    def add_record(self, record):
+        """Add record to collected records."""
+        self.records[record['recid']] = record
+
+
+class MultipartJsonLogger(JsonLogger):
+    """Log multipart statistics to file."""
+
+    def __init__(self):
+        """Constructor."""
+        super().__init__('multipart_stats.json', 'multipart_records.json')
+        self.document_pid = 0
+
+    def add_log(self, exc, key=None, value=None, output=None):
+        """Add exception log."""
+        self.resolve_error_type(exc, output, key, value)
+
+    def next_doc_pid(self):
+        """Get the next available fake doc pid."""
+        self.document_pid += 1
+        return self.document_pid
+
+    def add_recid_to_stats(self, recid):
+        """Add recid to stats."""
+        if recid not in self.stats:
+            self.stats[recid] = {
+                'recid': recid,
+                'manual_migration': [],
+                'unexpected_value': [],
+                'missing_required_field': [],
+                'lost_data': [],
+                'volumes': [],
+                'clean': True,
+            }
+
+    def _create_document(self, obj, recid):
+        """Create a new document object."""
+        return {
+            '$schema': 'https://127.0.0.1:5000/schemas/documents/'
+                       'document-v1.0.0.json',
+            '_migration': {
+                'record_type': 'document',
+                'multipart_recid': recid,
+            },
+            **obj,
+        }
+
+    def add_record(self, record):
+        """Add log record."""
+        recid = record['legacy_recid']
+        self.records[recid] = record
+
+        # Create a new document for each volume
+        for obj in record['_migration']['volumes']:
+            doc_pid = '{}-doc-{}'.format(recid, self.next_doc_pid())
+            document = self._create_document(obj, recid)
+            self.stats[recid]['volumes'].append(doc_pid)
+            self.records[doc_pid] = document
+
+
+class SerialJsonLogger(JsonLogger):
+    """Log migration statistic to file controller."""
+
+    def __init__(self):
+        """Constructor."""
+        super().__init__('serial_stats.json', 'serial_records.json')
+
+    def add_log(self, exc, key=None, value=None, output=None):
+        """Add exception log."""
+        pass
+
+    def _add_to_stats(self, record):
+        """Update serial stats."""
+        title = record['title']['title']
+        if title in self.stats:
+            self.stats[title]['documents'].append(record['recid'])
         else:
-            filename = '{0}/{1}_{2}.json'.format(rectype, rectype,
-                                                 stored_parent['recid'])
-        filepath = os.path.join(self._logs_path, filename)
-        with open(filepath, 'r+') as file:
-            parent = json.load(file)
-            key_name = '_migration_relation_{0}_recids'.format(rectype)
-            if key_name not in parent:
-                parent[key_name] = []
-            parent[key_name].append(related_recid)
-            file.seek(0)
-            file.truncate(0)
-            json.dump(parent, file, indent=2)
+            self.stats[title] = {
+                'title': title,
+                'issn': record.get('issn', None),
+                'documents': [record['recid']],
+                'similars': {
+                    'same_issn': [],
+                    'similar_title': [],
+                }
+            }
+
+    def _add_to_record(self, record):
+        """Update serial record."""
+        del record['recid']
+        title = record['title']['title']
+        self.records[title] = record
+
+    def add_record(self, record):
+        """Add serial to collected records."""
+        title = record['title']
+        if len(title) > 1:
+            for title in record['title']:
+                new_record = copy.deepcopy(record)
+                new_record['title'] = title
+                self._add_to_stats(new_record)
+                self._add_to_record(new_record)
+        else:
+            record['title'] = record['title'][0]
+            self._add_to_stats(record)
+            self._add_to_record(record)
+
+    def _add_children(self):
+        """Add children to collected record."""
+        for record in self.records.values():
+            record['_migration']['children'] = \
+                self.stats[record['title']['title']]['documents']
+
+    def _match_similar(self):
+        """Match similar serials."""
+        items = self.stats.items()
+        for title1, stat1 in items:
+            for title2, stat2 in items:
+                if title1 == title2:
+                    continue
+                if same_issn(stat1, stat2):
+                    if title2 not in stat1['similars']['same_issn']:
+                        stat1['similars']['same_issn'].append(title2)
+                    if title1 not in stat2['similars']['same_issn']:
+                        stat2['similars']['same_issn'].append(title1)
+                else:
+                    ratio = compare_titles(title1, title2)
+                    if 95 <= ratio < 100:
+                        if title2 not in stat1['similars']['similar_title']:
+                            stat1['similars']['similar_title'].append(title2)
+                        if title1 not in stat2['similars']['similar_title']:
+                            stat2['similars']['similar_title'].append(title1)
+
+    def save(self):
+        """Save serials and update children and simliar matches."""
+        self._add_children()
+        self._match_similar()
+        super().save()

--- a/cds_migrator_kit/records/records.py
+++ b/cds_migrator_kit/records/records.py
@@ -35,10 +35,12 @@ class CDSRecordDump(RecordDump):
                  source_type='marcxml',
                  latest_only=False,
                  pid_fetchers=None,
-                 dojson_model=marc21):
+                 dojson_model=marc21,
+                 logger=None):
         """Initialize."""
-        super(self.__class__, self).__init__(data, source_type, latest_only,
-                                             pid_fetchers, dojson_model)
+        super().__init__(data, source_type, latest_only, pid_fetchers,
+                         dojson_model)
+        self.logger = logger
         cli_logger.info('\n=====#RECID# {0} INIT=====\n'.format(data['recid']))
 
     @property
@@ -83,10 +85,10 @@ class CDSRecordDump(RecordDump):
         dt = arrow.get(data['modification_datetime']).datetime
 
         exception_handlers = {
-            UnexpectedValue: migration_exception_handler,
-            MissingRequiredField: migration_exception_handler,
-            ManualMigrationRequired: migration_exception_handler,
-            }
+            UnexpectedValue: migration_exception_handler(self.logger),
+            MissingRequiredField: migration_exception_handler(self.logger),
+            ManualMigrationRequired: migration_exception_handler(self.logger),
+        }
         if self.source_type == 'marcxml':
             marc_record = create_record(data['marcxml'])
             try:

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/base.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/base.html
@@ -8,9 +8,39 @@
   <head>
     <meta charset="utf-8" />
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <style>
+      .tooltip-inner {
+        max-width: 300px;
+      }
+    </style>
   </head>
   <body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item{% if not rectype %} active{% endif %}">
+        <a class="nav-link" href="/results">CDS-Migrator-Kit</a>
+      </li>
+      <li class="nav-item{% if rectype == 'document' %} active{% endif %}">
+        <a class="nav-link" href="/results/document">Documents</a>
+      </li>
+      <li class="nav-item{% if rectype == 'serial' %} active{% endif %}">
+        <a class="nav-link" href="/results/serial">Serials</a>
+      </li>
+      <li class="nav-item{% if rectype == 'multipart' %} active{% endif %}">
+        <a class="nav-link" href="/results/multipart">Multipart Monographs</a>
+      </li>
+    </ul>
+  </div>
+</nav>
+
     {%- block page_body %}
 
     {%- endblock page_body %}

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/document.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/document.html
@@ -1,0 +1,70 @@
+{#
+ Copyright (C) 2015-2018 CERN.
+  cds-migrator-kit is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.CDS_MIGRATOR_KIT_BASE_TEMPLATE %}
+
+{%- block page_body %}
+
+  <table class="table table-bordered">
+    <thead class="thead-dark">
+    <tr>
+      <th scope="col" style="position: sticky; top:0; ">Recid</th>
+      <th scope="col" style="position: sticky; top:0; ">Unexpected Value</th>
+      <th scope="col" style="position: sticky; top:0; ">Missing required</th>
+      <th scope="col" style="position: sticky; top:0; ">Manual Migration</th>
+      <th scope="col" style="position: sticky; top:0; ">Lost data fields</th>
+      <th scope="col" style="position: sticky; top:0; ">Document</th>
+    </tr>
+    </thead>
+    <tbody class="table-hover">
+    {% for stat in stats_sorted_by_key %}
+      <tr {% if stat.clean %}class="table-success"{% endif %}>
+        <th scope="row"><a href="https://cds.cern.ch/record/{{ stat.recid }}">{{ stat.recid }}</a></th>
+        <td>
+          {% for val in stat.unexpected_value %}
+            <span data-toggle="tooltip" data-placement="top" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.missing_required_field %}
+            <span data-toggle="tooltip" data-placement="left" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.manual_migration %}
+            <span data-toggle="tooltip" data-placement="left" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.lost_data %}
+            {% for missing in val.missing %}
+              {{ missing }}<br />
+            {% endfor %}
+          {% endfor %}
+        </td>
+        <td>
+          {% if not stat.lost_data %}
+            <a href="/record/document/{{ stat.recid }}">View</a>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <script>
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip()
+    })
+  </script>
+
+{%- endblock %}

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/index.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/index.html
@@ -1,3 +1,4 @@
+
 {#
  Copyright (C) 2015-2018 CERN.
   cds-migrator-kit is free software; you can redistribute it and/or modify it
@@ -5,67 +6,3 @@
 #}
 
 {%- extends config.CDS_MIGRATOR_KIT_BASE_TEMPLATE %}
-
-{%- block page_body %}
-
-  <table class="table table-bordered">
-    <thead class="thead-dark">
-    <tr>
-      <th scope="col" style="position: sticky; top:0; ">Recid (Legacy link)</th>
-      <th scope="col" style="position: sticky; top:0; ">Unexpected Value</th>
-      <th scope="col" style="position: sticky; top:0; ">Missing required</th>
-      <th scope="col" style="position: sticky; top:0; ">Manual Migration</th>
-      <th scope="col" style="position: sticky; top:0; ">Lost data fields</th>
-      {% if results[0].record_type == 'serial' %}
-        <th scope="col" style="position: sticky; top:0; ">Exact series</th>
-        <th scope="col" style="position: sticky; top:0; ">Similar series</th>
-      {% endif %}
-      <th scope="col" style="position: sticky; top:0; ">Output</th>
-    </tr>
-    </thead>
-    <tbody class="table-hover">
-    {% for elem in results %}
-      <tr {% if elem.clean %}class="table-success"{% endif %}>
-        <th scope="row"><a href="https://cds.cern.ch/record/{{ elem.recid }}">{{ elem.recid }}</a></th>
-        <td>
-          {% for val in elem.unexpected_value %}
-            {{ val }}<br>
-          {% endfor %}
-        </td>
-        <td>
-          {% for val in elem.missing_required_field %}
-            {{ val }},
-          {% endfor %}
-        </td>
-        <td>{% for val in elem.manual_migration %}
-          {{ val }},
-        {% endfor %}</td>
-        <td>{% for val in elem.lost_data %}
-          {{ val }},
-        {% endfor %}</td>
-        {% if elem.record_type == 'serial' %}
-          <td>
-            {{ elem.exact_series }}
-          </td>
-          <td>
-            {{ elem.similar_series }}
-          </td>
-        {% endif %}
-        <td>
-          {% if not elem.lost_data %}
-            {% if elem.extracted_records %}
-              {% for index in elem.extracted_records %}
-                <a href="/record/{{ elem.record_type }}/{{ elem.recid }}_{{ index }}">View {{ index }}</a>
-              {% endfor %}
-            {% else %}
-              <a href="/record/{{ elem.record_type }}/{{ elem.recid }}">View</a>
-            {% endif %}
-          {% endif %}
-        </td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
-
-{%- endblock %}
-

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/multipart.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/multipart.html
@@ -1,0 +1,79 @@
+{#
+ Copyright (C) 2015-2018 CERN.
+  cds-migrator-kit is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.CDS_MIGRATOR_KIT_BASE_TEMPLATE %}
+
+{%- block page_body %}
+
+  <table class="table table-bordered">
+    <thead class="thead-dark">
+    <tr>
+      <th scope="col" style="position: sticky; top:0; ">Recid</th>
+      <th scope="col" style="position: sticky; top:0; ">Unexpected Value</th>
+      <th scope="col" style="position: sticky; top:0; ">Missing required</th>
+      <th scope="col" style="position: sticky; top:0; ">Manual Migration</th>
+      <th scope="col" style="position: sticky; top:0; ">Lost data fields</th>
+      <th scope="col" style="position: sticky; top:0; ">Multipart</th>
+      <th scope="col" style="position: sticky; top:0; ">Volumes</th>
+    </tr>
+    </thead>
+    <tbody class="table-hover">
+    {% for stat in stats_sorted_by_key %}
+      <tr {% if stat.clean %}class="table-success"{% endif %}>
+        <th scope="row"><a href="https://cds.cern.ch/record/{{ stat.recid }}">{{ stat.recid }}</a></th>
+        <td>
+          {% for val in stat.unexpected_value %}
+            <span data-toggle="tooltip" data-placement="top" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.missing_required_field %}
+            <span data-toggle="tooltip" data-placement="left" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.manual_migration %}
+            <span data-toggle="tooltip" data-placement="left" title="{{ val.message }}">
+              {{ val.key }}{{ val.subfield }}: <code>{{ val.value }}</code>
+            </span><br />
+          {% endfor %}
+        </td>
+        <td>
+          {% for val in stat.lost_data %}
+            {% for missing in val.missing %}
+              {{ missing }}<br />
+            {% endfor %}
+          {% endfor %}
+        </td>
+        <td>
+          {% if not stat.lost_data %}
+            <a href="/record/multipart/{{ stat.recid }}">View</a>
+          {% endif %}
+        </td>
+        <td nowrap>
+          {% if not stat.lost_data %}
+            {% for doc_pid in stat.volumes %}
+              <a href="/record/multipart/{{ doc_pid }}">Volume: {{ records[doc_pid].volume }}</a>
+              <br />
+            {% endfor %}
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <script>
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip()
+    })
+  </script>
+
+{%- endblock %}

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/rectype_missing.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/rectype_missing.html
@@ -1,0 +1,19 @@
+{#
+ Copyright (C) 2015-2018 CERN.
+  cds-migrator-kit is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.CDS_MIGRATOR_KIT_BASE_TEMPLATE %}
+
+{%- block page_body %}
+
+<div class="container">
+  <div class="alert alert-danger" role="alert">
+    <h4 class="alert-heading">No stats exists for record type "{{ rectype }}"</h4>
+    To generate statistics for this record type please run:
+    <code>migrator report dryrun --rectype {{ rectype }} &lt;sources&gt;</code>
+  </div>
+</div>
+
+{%- endblock %}

--- a/cds_migrator_kit/records/templates/cds_migrator_kit_records/serial.html
+++ b/cds_migrator_kit/records/templates/cds_migrator_kit_records/serial.html
@@ -1,0 +1,50 @@
+{#
+ Copyright (C) 2015-2018 CERN.
+  cds-migrator-kit is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.CDS_MIGRATOR_KIT_BASE_TEMPLATE %}
+
+{%- block page_body %}
+
+  <table class="table table-bordered">
+    <thead class="thead-dark">
+    <tr>
+      <th scope="col" style="position: sticky; top:0; ">Serial Name</th>
+      <th scope="col" style="position: sticky; top:0; ">Documents</th>
+      <th scope="col" style="position: sticky; top:0; ">Same ISSN</th>
+      <th scope="col" style="position: sticky; top:0; ">Similar Titles</th>
+    </tr>
+    </thead>
+    <tbody class="table-hover">
+    {% for stat in stats_sorted_by_key %}
+      <tr {% if stat.similars.same_issn or stat.similars.similar_title %}class="table-warning"{% endif %}>
+        <th scope="row">{{ stat.title }}</th>
+        <td>
+          {% for recid in stat.documents %}
+            <a href="https://cds.cern.ch/record/{{ recid }}">{{ recid }}</a>,
+            {% if loop.index % 12 == 0 %}<br>{% endif %}
+          {% endfor %}
+        </td>
+        <td>
+          {% for title in stat.similars.same_issn %}
+            {% for recid in stats[title].documents %}
+              <a href="https://cds.cern.ch/record/{{ recid }}">"{{ title }}"</a>,<br />
+            {% endfor %}
+          {% endfor %}
+        </td>
+        <td>
+          {% for title in stat.similars.similar_title %}
+            {% for recid in stats[title].documents %}
+              <a href="https://cds.cern.ch/record/{{ recid }}">"{{ title }}"</a>,<br />
+            {% endfor %}
+          {% endfor %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{%- endblock %}
+

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup_requires = [
 install_requires = [
     'cds-dojson>=0.9.0',
     'Flask-BabelEx>=0.9.3',
-    'invenio-app>=1.0.4,<1.2.0',
-    'invenio-base>=1.0.0,<1.1.0',
+    'invenio-app>=1.0.4',
+    'invenio-base>=1.0.0,<1.2.0',
     'invenio-config>=1.0.0',
     'invenio-logging>=1.0.0',
     'invenio-db[postgresql,versioning]>=1.0.0',
@@ -56,9 +56,10 @@ install_requires = [
     'invenio-records>=1.0.0',
     'invenio-records-files>=1.0.0a10',
     'pathlib>=1.0.1',
-    'importlib-metadata==0.17',
+    'importlib-metadata==0.18',
     'pluggy==0.11.0',
     'fuzzywuzzy>=0.17.0',
+    'python-Levenshtein>=0.12',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Update allowed hosts
* Rectype specific loggers
* Display more exception information
* Drop python 2.7 support

The latest changes have been deployed to http://books-migrator-qa.web.cern.ch/results.

Closes #36 
Closes https://github.com/CERNDocumentServer/cds-dojson/issues/222