### PR TITLE
videos: small file improvements

### DIFF
--- a/cds_migrator_kit/videos/weblecture_migration/transform/transform_files.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/transform_files.py
@@ -322,10 +322,20 @@ class TransformFiles:
                     folder=self.media_folder,
                     files_list=[frame["url"].strip("/") for frame in frames_list] # Get the paths
                 )
+        
+        # ~~~~SUBTITLES~~~~            
+        # Get subtitles from data.v2.json
+        subtitles = [item["url"].strip("/") for item in data.get("captions", [])]
+        self._add_files_to_file_json(
+            json_key="additional_files",
+            folder=self.media_folder,
+            files_list=subtitles
+        )
                 
         # Exclude already added files from additional files
         subformat_paths = [item["path"] for item in subformats]
-        additional_files = [file for file in files_paths if file not in subformat_paths+highest_presenter_presentation]
+        already_added_files = set(subformat_paths + highest_presenter_presentation + subtitles)
+        additional_files = [file for file in files_paths if file not in already_added_files]
         
         # Add additional files
         self._add_files_to_file_json(

--- a/tests/cds-videos/data/files/media_data/2025/1/data.v2.json
+++ b/tests/cds-videos/data/files/media_data/2025/1/data.v2.json
@@ -60,5 +60,13 @@
       "time": 10,
       "url": "/2025/1/frame-10.jpg"
     }
+  ],
+  "captions": [
+    {
+      "format": "vtt",
+      "lang": "en",
+      "text": "English",
+      "url": "/2025/1/1_en.vtt"
+    }
   ]
 }

--- a/tests/cds-videos/test_videos_transform_files.py
+++ b/tests/cds-videos/test_videos_transform_files.py
@@ -39,7 +39,7 @@ def entry_files_single():
 
 
 def test_transform_files_composite(entry_files_composite, base_app):
-    """Test migration tramsform files."""
+    """Test migration transform files."""
     with base_app.app_context():
         # Load test data
         entry = {}
@@ -63,7 +63,7 @@ def test_transform_files_composite(entry_files_composite, base_app):
 
 
 def test_transform_files_single(entry_files_single, base_app):
-    """Test migration tramsform files."""
+    """Test migration transform files."""
     with base_app.app_context():
         # Load test data
         entry = {}


### PR DESCRIPTION
- Since the `data.v2.json` is the source of truth for the files, subtitles are also retrieved from data.v2.json. Previously, subtitles were extracted from the record marcXML.
- `cds-videos` uses the first frame file by it's name: [frame-1.jpg](https://github.com/search?q=repo%3ACERNDocumentServer%2Fcds-videos%20frame-1&type=code) as the video poster. Frame files are renaming(renamed by file key not the file itself) when copying into bucket.