### PR TITLE
videos: transform _curation fields

### DIFF
--- a/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
@@ -31,13 +31,6 @@ class VideoLecture(CdsOverdo):
 
     __ignore_keys__ = {
         "003",
-        # 340: Drop streaming video, anything else we copy over to curation field.
-        "340__a",  # Physical medium -> curation field
-        "340__d",  # Physical medium/recording technique -> curation field
-        "340__9",  # Physical medium/CD-ROM -> curation field
-        "340__k",  # Physical medium/ -> curation field
-        "340__j",  # Physical medium/ -> curation field
-        "340__8",  # Physical medium/id? -> curation field https://cds.cern.ch/record/2234827
         # check with JY
         "961__h",  # Hour? TODO? check with JY
         "961__l",  # Library? TODO? check with JY
@@ -64,24 +57,12 @@ class VideoLecture(CdsOverdo):
         "5061_5",
         "5061_a",
         "5061_2",
-        # Location (Shelving/Library)
-        "852__c",  # Location (Shelving/Library)
-        "852__b",  # Location (Shelving/?)
-        "852__8",  # Location (Shelving/id?) https://cds.cern.ch/record/2234827
-        "852__h",  # Location (Shelving) example: https://cds.cern.ch/record/254588/
-        "852__a",  # Location (Shelving) example: https://cds.cern.ch/record/558348
-        "852__x",  # Location (Shelving/ type? DVD) example: https://cds.cern.ch/record/690000/
-        "852__9",  # Location (Shelving/ note?) example: https://cds.cern.ch/record/2233722
         # Date/Extra Reduntant
         "260__c",  # Redundant (more detailed value is in 269__c imprint.pub_date)
         "260__a",
         "260__b",
         # Contributor?
         "700__m",  # author's email
-        # Internal Note
-        "595__a",  # Internal Note --> curation field
-        "595__s",  # Subject note --> curation field
-        "595__z",  # SOME RECORD HAVE UNCL as value, do we keep it? what does UNCL mean
         # OAI
         "0248_a",  # oai identifier
         "0248_p",  # oai identifier
@@ -206,6 +187,22 @@ class VideoLecture(CdsOverdo):
         # "7870_i",  # Relationship information
         # "7870_r",  # Report number
         # "7870_w",  # Record control number
+        # "852__c",  # Location _curation
+        # "852__b",  # Location _curation
+        # "852__8",  # Location _curation https://cds.cern.ch/record/2234827
+        # "852__h",  # Location _curation example: https://cds.cern.ch/record/254588/
+        # "852__a",  # Location _curation example: https://cds.cern.ch/record/558348
+        # "852__x",  # Location _curation example: https://cds.cern.ch/record/690000/
+        # "852__9",  # Location _curation example: https://cds.cern.ch/record/2233722
+        # "340__a",  # Physical medium -> curation, drop streaming video
+        # "340__d",  # Physical medium/recording technique -> curation field
+        # "340__9",  # Physical medium/CD-ROM -> curation field
+        # "340__k",  # Physical medium/ -> curation field
+        # "340__j",  # Physical medium/ -> curation field
+        # "340__8",  # Physical medium/id? -> curation field https://cds.cern.ch/record/2234827
+        # "595__a",  # Internal Note --> curation field
+        # "595__s",  # Subject note --> curation field
+        # "595__z",  # SOME RECORD HAVE UNCL as value, do we keep it? what does UNCL mean
         # "970__a",  # alternative identifier, indico id?
     }
 

--- a/cds_migrator_kit/videos/weblecture_migration/transform/xml_processing/quality/curation.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/xml_processing/quality/curation.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+#
+# CDS-Videos is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""CDS-Videos helper migration module."""
+
+
+def transform_subfields(key, value):
+    """Helper to transform MARC subfields into key-prefixed strings."""
+    value = dict(value)
+    output = []
+    for subfield, subvalue in value.items():
+        if isinstance(subvalue, (list, tuple)):
+            for item in subvalue:
+                output.append(f"{key}{subfield}:{item}")
+        else:
+            output.append(f"{key}{subfield}:{subvalue}")
+    return output


### PR DESCRIPTION
Only last commit for review :)


- Tag `852` (physical_location) transformed as `_curation.physical_location` with marc tags (852__a:....)
- Tag `340` (physical_medium) transformed as `_curation.physical_medium` with marc tags (340__a:....)
- Tag `595` (internal_note) transformed as `_curation.internal_note` with marc tags (595__a:....)