### PR TITLE
videos: transform doi and collections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           pip install -U pip setuptools wheel
           pip install uritemplate
+          pip install "pytest-cov<4.0.0"
           pip install ".[$EXTRAS]"
           pip freeze
           docker --version

--- a/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
@@ -36,18 +36,9 @@ class VideoLecture(CdsOverdo):
         "961__l",  # Library? TODO? check with JY
         "961__a",  # ? TODO? check with JY
         "961__b",  # ? TODO? check with JY
-        "964__a",  # Item owner TODO? check with JY
         "901__u",  # Affiliation at Conversion? TODO? check with JY
-        "583__a",  # Action note / curation TODO? check with JY
-        "583__c",  # Action note / curation TODO? check with JY
-        "583__z",  # Action note / curation TODO? check with JY
-        "583__8",  # Action note / curation TODO? check with JY
-        "306__a",  # ? TODO? check with JY
-        "336__a",  # ? TODO? check with JY
         "981__a",  # duplicate record id TODO? check with JY
         # Category, Collection, Series, Keywords
-        "980__a",  # collection tag
-        "980__b",  # Secondary collection indicator
         "490__a",  # TODO Series
         "490__v",  # Series: volume
         "690C_a",  # collection name
@@ -59,17 +50,14 @@ class VideoLecture(CdsOverdo):
         "5061_2",
         # Date/Extra Reduntant
         "260__c",  # Redundant (more detailed value is in 269__c imprint.pub_date)
-        "260__a",
-        "260__b",
+        "260__a",  # Usually Geneva
+        "260__b",  # Usually CERN
         # Contributor?
         "700__m",  # author's email
         # OAI
         "0248_a",  # oai identifier
         "0248_p",  # oai identifier
         "0248_q",
-        # DOI
-        "0247_a",  # doi value
-        "0247_2",
         # IGNORE
         "111__z",  # End date (indico)
         "518__h",  # Lectures: Starting time
@@ -96,7 +84,7 @@ class VideoLecture(CdsOverdo):
         "084__2",  # Other classification number
         "960__a",  # Base number
         # IMPLEMENTED
-        # "520__a",  # Note (-> description.type = abstract
+        # "520__a",  # description
         # "001",
         # "041__a",  # languages
         # "906__p",  # event speakers
@@ -204,12 +192,26 @@ class VideoLecture(CdsOverdo):
         # "595__s",  # Subject note --> curation field
         # "595__z",  # SOME RECORD HAVE UNCL as value, do we keep it? what does UNCL mean
         # "970__a",  # alternative identifier, indico id?
+        # "0247_a",  # doi value
+        # "0247_2",
+        # "980__a",  # collection tag
+        # "980__b",  # Secondary collection indicator
+        # "583__a",  # Action note / curation
+        # "583__c",  # Action note / curation
+        # "583__z",  # Action note / curation
+        # "583__8",  # Action note / curation
+        # "964__a",  # curation
+        # "336__a",  # curation
+        # "306__a",  # Duration, curation
     }
 
     _default_fields = {
         "lecture_infos": [],
         "_curation": {},
-        "contributors": []
+        "contributors": [],
+        "alternate_identifiers": [],
+        "additional_languages": [],
+        "collections": [],
     }
 
 

--- a/cds_migrator_kit/videos/weblecture_migration/transform/transform.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/transform.py
@@ -419,6 +419,15 @@ class CDSToVideosRecordEntry(RDMRecordEntry):
             """Return additional_descriptions."""
             return get_values_in_json(json_data, "additional_descriptions", type=list)
 
+        def get_collections(json_data):
+            """Return collection tags."""
+            collections = get_values_in_json(json_data, "collections", type=list)
+            # If collection is missing add `Lectures`
+            if not collections:
+                collections.append("Lectures")
+            # TODO after implementing restrictions, if not CMS or Atlas add `Lectures/Restricted General Talks`
+            return collections
+
         record_date = reformat_date(entry)
         metadata = {
             "title": entry["title"],
@@ -437,6 +446,10 @@ class CDSToVideosRecordEntry(RDMRecordEntry):
             "additional_descriptions": get_additional_descriptions(entry),
             "license": entry.get("license"),
             "copyright": entry.get("copyright"),
+            "doi": entry.get("doi"),
+            "alternate_identifiers": entry.get("alternate_identifiers"),
+            "additional_languages": entry.get("additional_languages"),
+            "collections": get_collections(entry),
         }
         _curation = get_curation(entry)
         # If report number exists put it in curation

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -53,10 +53,12 @@ def add_tag_to_marcxml(marcxml, tag, subfields, ind1=" "):
     # Create new datafield element
     new_datafield = ET.Element("datafield", tag=tag, ind1=ind1, ind2=" ")
 
-    # Add subfields
-    for code, value in subfields.items():
-        subfield = ET.SubElement(new_datafield, "subfield", code=code)
-        subfield.text = value
+    for code, values in subfields.items():
+        if not isinstance(values, list):
+            values = [values]  # Normalize to list
+        for value in values:
+            subfield = ET.SubElement(new_datafield, "subfield", code=code)
+            subfield.text = value
 
     # Append the new datafield
     root.append(new_datafield)


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-videos/issues/2041
closes https://github.com/CERNDocumentServer/cds-videos/issues/2042

### New rules
- Tag `0247` (DOI) transformed as DOI if it's starting with `10.17.181`, or alternate_identifiers with `DOI` scheme.
- Tag `980` collections transformed as `collections`
- Tag `964`  transformed as `_curation.964` with marc tags (964__a:....)
- Tag `853`  transformed as `_curation.853` with marc tags (853__a:....)
- Tag `336`  transformed as `_curation.336` with marc tags (336__a:....)

### Improvements
- Tag`269`(imprint) `b` name of publication  transformed as contributor with role `Producer`
- Tag`041`(language) if we have multiple languages, first one used as a main language and others added as`additional_languages `