### PR TITLE
videos: improve transform

### DIFF
--- a/cds_migrator_kit/videos/README.md
+++ b/cds_migrator_kit/videos/README.md
@@ -8,7 +8,11 @@ Run the following command on webnode: `cds-migration-01` to dump a subset of rec
 
 .. code-block:: bash
 
-    inveniomigrator dump records -q '8567_x:"Absolute master path" 8567_d:/mnt/master_share* -980__C:MIGRATED -980__c:DELETED -5831_a:digitized' --file-prefix lectures --chunk-size=1000
+    inveniomigrator dump records -q "8567_x:'Absolute master path' 8567_d:/mnt/master_share* -980__C:MIGRATED -980__c:DELETED -5831_a:digitized" --file-prefix lectures --chunk-size=1000
+
+
+> **Note:**  
+> For the query, be sure to use single quotes (`'`) instead of double quotes (`"`),  
 
 Place your dumps into the `cds_migrator_kit/videos/weblecture_migration/data/weblectures/dump/` folder, or update the `records/weblectures/extract/dirpath:` in `cds_migrator_kit/videos/weblecture_migration/streams.yaml`.
 

--- a/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/models/video_lecture.py
@@ -27,7 +27,7 @@ from .base import model as base_model
 class VideoLecture(CdsOverdo):
     """Translation Index for CERN Video Lectures."""
 
-    __query__ = '8567_.x:"Absolute master path" 8567_.d:/mnt/master_share* -980__.C:MIGRATED -980__.c:DELETED -5831_.a:digitized'
+    __query__ = "8567_.x:'Absolute master path' 8567_.d:/mnt/master_share* -980__.C:MIGRATED -980__.c:DELETED -5831_.a:digitized"
 
     __ignore_keys__ = {
         "003",
@@ -36,10 +36,6 @@ class VideoLecture(CdsOverdo):
         "961__l",  # Library? TODO? check with JY
         "961__a",  # ? TODO? check with JY
         "961__b",  # ? TODO? check with JY
-        # Category, Collection, Series, Keywords
-        "690C_a",  # collection name
-        # Contributor?
-        "700__m",  # author's email
         # IGNORE
         "111__z",  # End date (indico)
         "518__h",  # Lectures: Starting time
@@ -200,6 +196,7 @@ class VideoLecture(CdsOverdo):
         # "5061_a",  # Restriction
         # "5061_2",  # Restriction
         # "901__u",  # Affiliation
+        # "690C_a",  # collection name -> keywords
     }
 
     _default_fields = {

--- a/cds_migrator_kit/videos/weblecture_migration/transform/transform.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/transform.py
@@ -360,9 +360,12 @@ class CDSToVideosRecordEntry(RDMRecordEntry):
             """Return keywords."""
             keywords = json_data.get("keywords", [])
             subject_categories = json_data.get("subject_categories", [])
+            subject_indicators = json_data.get("subject_indicators", [])
 
             all_keywords = [
-                keyword for keyword in keywords + subject_categories if keyword
+                keyword
+                for keyword in keywords + subject_categories + subject_indicators
+                if keyword
             ]
             return all_keywords
 

--- a/cds_migrator_kit/videos/weblecture_migration/transform/xml_processing/rules/video_lecture.py
+++ b/cds_migrator_kit/videos/weblecture_migration/transform/xml_processing/rules/video_lecture.py
@@ -461,6 +461,18 @@ def corporate_author(self, key, value):
     return None
 
 
+@model.over("subject_indicators", "^690C_")
+@for_each_value
+def subject_indicators(self, key, value):
+    """Translates subject_indicators as keywords from tag 690C."""
+    subject = value.get("a", "").strip()
+    if subject:
+        if subject not in ["ACAD", "CERN", "TALK", "movingimages", "SSLP", "reviewed"]:
+            # checking if anything else stored in this field
+            raise UnexpectedValue(field=key, subfield="a", value=subject)
+    return {"name": subject}
+
+
 @model.over("subject_categories", "(^65017)|(^65027)")
 @for_each_value
 def subject_categories(self, key, value):

--- a/tests/cds-videos/test_videos_transform_rules.py
+++ b/tests/cds-videos/test_videos_transform_rules.py
@@ -335,11 +335,16 @@ def test_transform_keywords(dumpdir, base_app):
         res = load_and_dump_revision(modified_data)
         assert len(res["keywords"]) == 1
 
-        # Transform record subject category will be added as keyword
+        # Transform record subject category and subject indicator will be added as keyword
         record_entry = CDSToVideosRecordEntry()
         metadata = record_entry._metadata(res)
         assert "keywords" in metadata
-        assert len(metadata["keywords"]) == 3
+        assert len(metadata["keywords"]) == 6
+        keywords = [keyword["name"] for keyword in metadata["keywords"]]
+        # Tag 690 subject indicators
+        assert "TALK" in keywords
+        assert "movingimages" in keywords
+        assert "CERN" in keywords
 
 
 def test_transform_accelerator_experiment(dumpdir, base_app):
@@ -644,8 +649,10 @@ def test_transform_subject_category(dumpdir, base_app):
         modified_data = data[0]
         # Remove 490 it's also transformed as keyword
         record_marcxml = modified_data["record"][-1]["marcxml"]
+        record_marcxml = remove_tag_from_marcxml(record_marcxml, "490")
+        # Remove 690 it's also transformed as keyword
         modified_data["record"][-1]["marcxml"] = remove_tag_from_marcxml(
-            record_marcxml, "490"
+            record_marcxml, "690"
         )
 
         # Extract record


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-videos/issues/2053
closes https://github.com/CERNDocumentServer/cds-videos/issues/2054

- Tag `901__` affiliations  transformed as `contributors.affiliations` if role is speaker and only one speaker
- Tag `8564_` if url has `digital-memory`-> digitized transformed as `_curation.digitized` 
- Report number changed to array, no need to be only one value
- If record has multiple departments values are concatenated
- Tag `690C` subject indicators transformed as `keywords`