### PR TITLE
global: ensure to have only one logger for runner

### DIFF
--- a/cds_migrator_kit/rdm/records/load/load.py
+++ b/cds_migrator_kit/rdm/records/load/load.py
@@ -33,7 +33,6 @@ from cds_migrator_kit.errors import (
     GrantCreationError,
     ManualImportRequired,
 )
-from cds_migrator_kit.reports.log import MigrationProgressLogger, RecordStateLogger
 
 
 def import_legacy_files(filepath):
@@ -59,14 +58,16 @@ class CDSRecordServiceLoad(Load):
         dry_run=False,
         legacy_pids_to_redirect=None,
         collection=None,
+        migration_logger=None,
+        record_state_logger=None,
     ):
         """Constructor."""
         self.dry_run = dry_run
         self.legacy_pids_to_redirect = {}
         self.clc_sync = False
         self.collection = collection
-        self.migration_logger = MigrationProgressLogger(collection=collection)
-        self.record_state_logger = RecordStateLogger(collection=collection)
+        self.migration_logger = migration_logger
+        self.record_state_logger = record_state_logger
         if legacy_pids_to_redirect is not None:
             with open(legacy_pids_to_redirect, "r") as fp:
                 self.legacy_pids_to_redirect = json.load(fp)

--- a/cds_migrator_kit/rdm/records/transform/transform.py
+++ b/cds_migrator_kit/rdm/records/transform/transform.py
@@ -87,6 +87,8 @@ class CDSToRDMRecordEntry(RDMRecordEntry):
         dry_run=False,
         collection=None,
         restricted=False,
+        migration_logger=None,
+        record_state_logger=None,
     ):
         """Constructor."""
         self.missing_users_dir = missing_users_dir
@@ -95,8 +97,8 @@ class CDSToRDMRecordEntry(RDMRecordEntry):
         self.dry_run = dry_run
         self.collection = collection
         self.restricted = restricted
-        self.migration_logger = MigrationProgressLogger(collection=collection)
-        self.record_state_logger = RecordStateLogger(collection=collection)
+        self.migration_logger = migration_logger
+        self.record_state_logger = record_state_logger
         super().__init__(partial)
 
     def _created(self, entry):
@@ -716,6 +718,8 @@ class CDSToRDMRecordTransform(RDMRecordTransform):
         collection=None,
         restricted=False,
         plots=False,
+        migration_logger=None,
+        record_state_logger=None,
     ):
         """Constructor."""
         self.files_dump_dir = Path(files_dump_dir).absolute().as_posix()
@@ -725,8 +729,8 @@ class CDSToRDMRecordTransform(RDMRecordTransform):
         self.collection = collection
         self.restricted = restricted
         self.plots = plots
-        self.migration_logger = MigrationProgressLogger(collection=collection)
-        self.record_state_logger = RecordStateLogger(collection=collection)
+        self.migration_logger = migration_logger
+        self.record_state_logger = record_state_logger
         self.db_state = {"affiliations": CDSMigrationAffiliationMapping}
         super().__init__(workers, throw)
 
@@ -797,6 +801,8 @@ class CDSToRDMRecordTransform(RDMRecordTransform):
             dry_run=self.dry_run,
             collection=self.collection,
             restricted=self.restricted,
+            migration_logger=self.migration_logger,
+            record_state_logger=self.record_state_logger,
         ).transform(entry)
 
     def _draft(self, entry):


### PR DESCRIPTION
There were some global [changes](https://github.com/CERNDocumentServer/cds-migrator-kit/commit/98fc768c2e52e5a79b379f120225e2b05a1c4dcd) for logging (to run multiple migrations) and class changed that's why we need to have one logger per run otherwise we lose the logs