### PR TITLE
fix(rules): accept multiple titles in base rules

### DIFF
--- a/cds_migrator_kit/rdm/records/transform/xml_processing/rules/base.py
+++ b/cds_migrator_kit/rdm/records/transform/xml_processing/rules/base.py
@@ -570,8 +570,9 @@ def title(self, key, value):
     title = StringValue(value.get("a"))
     subtitle = StringValue(value.get("b", "")).parse()
     title.required()
+    title_string = title.parse()
+    alt_titles = self.get("additional_titles", [])
     if subtitle:
-        alt_titles = self.get("additional_titles", [])
         alt_titles.append(
             {
                 "title": subtitle,
@@ -579,7 +580,18 @@ def title(self, key, value):
             }
         )
         self["additional_titles"] = alt_titles
-    return title.parse()
+    if self.get("title") and title_string:
+        alt_titles.append(
+            {
+                "title": title_string,
+                "type": {"id": "subtitle"},
+            }
+        )
+        self["additional_titles"] = alt_titles
+        raise IgnoreKey("title")
+    if title_string:
+        return title_string
+    raise IgnoreKey("title")
 
 
 @model.over("rights", "^540__")

--- a/cds_migrator_kit/rdm/records/transform/xml_processing/rules/hr.py
+++ b/cds_migrator_kit/rdm/records/transform/xml_processing/rules/hr.py
@@ -365,11 +365,7 @@ def title(self, key, value):
         self["additional_titles"] = alt_titles
     identifiers = self.get("identifiers", [])
     rep_num = next(
-        (
-            identifier
-            for identifier in identifiers
-            if identifier["scheme"] == "cdsrn"
-        ),
+        (identifier for identifier in identifiers if identifier["scheme"] == "cdsrn"),
         {},
     ).get("identifier")
 
@@ -391,7 +387,6 @@ def title(self, key, value):
                 suffix += f"{number_stripped})"
                 title += suffix
     return title
-
 
 
 @model.over("meeting_cf", "^773__")

--- a/tests/cds-rdm/test_base_migration.py
+++ b/tests/cds-rdm/test_base_migration.py
@@ -47,15 +47,14 @@ class TestTitle:
     def test_title_missing_field_returns_empty(self):
         """Test that missing title returns empty string."""
         record = {}
-        result = title(record, "245__", {})
-        # StringValue with empty value returns empty string
-        assert result == ""
+        with pytest.raises(IgnoreKey):
+            title(record, "245__", {})
 
     def test_title_empty_string_returns_empty(self):
         """Test that empty title returns empty string."""
         record = {}
-        result = title(record, "245__", {"a": ""})
-        assert result == ""
+        with pytest.raises(IgnoreKey):
+            title(record, "245__", {"a": ""})
 
     def test_title_subtitle_appends_to_existing(self):
         """Test subtitle appends to existing additional_titles."""


### PR DESCRIPTION
Records might have multiple 245 fields and in this case we're overriding the value. 

Example:
- https://cds.cern.ch/record/2040167/export/xm
    - Title becomes the first 245__a value: `Environmental monitoring for the LEP project`
    - With the second 245 title becomes `""` since there's no value
- https://cds.cern.ch/record/2042168/export/xm
    - We're setting the title to the second 245__a value 


If there's multiple title, we can add as additional title?