### PR TITLE
feat(setup): Support python version 3.9 and 3.14 for RDM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, 3.14]
         requirements-level: [pypi]
         db-service: [postgresql14]
         include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,9 @@ rdm =
     invenio-app-rdm[opensearch2]==14.0.0b10.dev4
     cds-rdm @ git+https://github.com/CERNDocumentServer/cds-rdm@master#egg=cds-rdm&subdirectory=site
     invenio-preservation-sync==0.3.0
-    invenio-cern-sync @ git+https://github.com/cerndocumentserver/invenio-cern-sync@v0.6.0#egg=invenio-cern-sync
+    invenio-cern-sync @ git+https://github.com/CERNDocumentServer/invenio-cern-sync@v0.6.0#egg=invenio-cern-sync
+    invenio-rdm-migrator @ git+https://github.com/CERNDocumentServer/invenio-rdm-migrator@master#egg=invenio-rdm-migrator
+    invenio-query-parser @ git+https://github.com/CERNDocumentServer/invenio-query-parser@master#egg=invenio-query-parser
 
 videos =
     Flask-Security-Invenio==3.4.0

--- a/tests/cds-rdm/conftest.py
+++ b/tests/cds-rdm/conftest.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest fixtures."""
+
 import os
 from collections import namedtuple
 from os.path import dirname, join

--- a/tests/cds-rdm/test_bulletin_issue.py
+++ b/tests/cds-rdm/test_bulletin_issue.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """Tests suites."""
+
 import json
 from pathlib import Path
 

--- a/tests/cds-rdm/test_hr_migration.py
+++ b/tests/cds-rdm/test_hr_migration.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """Tests suites."""
+
 import json
 from pathlib import Path
 

--- a/tests/cds-rdm/test_thesis_migration.py
+++ b/tests/cds-rdm/test_thesis_migration.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """Tests suites."""
+
 import json
 from pathlib import Path
 


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-migrator-kit/issues/543