### PR TITLE
fix(rules): accept multiple descriptions in base rule

### DIFF
--- a/cds_migrator_kit/transform/xml_processing/rules/base.py
+++ b/cds_migrator_kit/transform/xml_processing/rules/base.py
@@ -58,6 +58,16 @@ def title(self, key, value):
 def description(self, key, value):
     """Translates description."""
     description_text = StringValue(value.get("a")).parse()
+    if self.get("description") and description_text:
+        additional_descriptions = self.get("additional_descriptions", [])
+        additional_descriptions.append(
+            {
+                "description": description_text,
+                "type": {"id": "other"},
+            }
+        )
+        self["additional_descriptions"] = additional_descriptions
+        raise IgnoreKey("description")
     return description_text
 
 


### PR DESCRIPTION
example record: https://cds.cern.ch/record/2936325
has 3 520 fields, with current rule we're overriding and getting the last one