### PR TITLE
fix(rules): assume day comes first in ambiguous date strings

### DIFF
--- a/cds_migrator_kit/rdm/records/transform/xml_processing/rules/base.py
+++ b/cds_migrator_kit/rdm/records/transform/xml_processing/rules/base.py
@@ -1138,7 +1138,7 @@ def normalize(date_str):
     if re.fullmatch(r"\d{4}[-/]\d{2}[-/]\d{2}", date_str):  # YYYY-MM-DD
         return parse(date_str).strftime("%Y-%m-%d")
 
-    dt = parse(date_str, default=datetime.datetime(1, 1, 1))
+    dt = parse(date_str, default=datetime.datetime(1, 1, 1), dayfirst=True)
 
     # If the user explicitly provided a day, keep the full date because the parse() adds day if not present
     if re.search(r"\b\d{1,2}(?:st|nd|rd|th)?\b", date_str, re.IGNORECASE):


### PR DESCRIPTION
Some Staff Association records have been migrated incorrectly in dev because the default behaviour of [`dateutil.parser.parse`](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse) is to assume the "American style" date format of MM/DD/YYYY.

See https://dev-cds-rdm.web.cern.ch/records/qsxpc-9b756 vs https://cds.cern.ch/record/2965876/export/hm?ln=en

Setting `dayfirst=True` makes it assume the first integer is the day and not the month.